### PR TITLE
Add environmental setting for a different database URL

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -35,8 +35,6 @@ script_location = alembic
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = mysql://root@localhost:3306/dsa
-
 
 # Logging configuration
 [loggers]

--- a/example.env
+++ b/example.env
@@ -1,3 +1,5 @@
+# Change and uncomment this if you want a different database URL.
+# DATABASE_URL=mysql://root@localhost:3306/dsa
 USE_AUTH=FALSE
 NO_AUTH_EMAIL=joe.schmoe@example.com
 USE_EMAIL=FALSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ blinker==1.4
 Flask==0.12.2
 Flask-Cors==3.0.2
 mysqlclient==1.3.10
+# psycopg2cffi==2.7.4  # Uncomment for postgresql support.
 PyJWT==1.5.0
 raven==6.1.0
 requests==2.17.3


### PR DESCRIPTION
 - Removes the sqlalchemy.url parameter from alembic.ini as it isn't
   used by `database_config.py`.
 - Adds an entry, commented out by default, to example.env to change
   the database url.
 - Adds a commented out requirement for a postgresql driver to
   requirements.txt.