### PR TITLE
Reloads server on code change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - db:mysql
     ports:
       - 8080:8080
+    volumes:
+      - '.:/src'
   # The SQL database
   db:
     image: mariadb:latest

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -17,9 +17,11 @@ ADD requirements.txt ./
 
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-ADD config ./config
-ADD membership ./membership
-ADD flask_app.py ./
+ADD config /src/config
+ADD membership /src/membership
+ADD flask_app.py /src
+
+WORKDIR /src
 
 EXPOSE 8080
 

--- a/example.env
+++ b/example.env
@@ -19,3 +19,7 @@ SUPER_USER_EMAIL=joe.schmoe@example.com
 # By default, docker compose will wire the containers running in docker to talk to each other.
 # If you want to configure the app to use your own local installation, uncomment this line
 # DATABASE_URL=mysql://root@127.0.0.1:3306/dsa
+
+# Reloads the Flask web server on code change. This should only be used for development and not
+# for production.
+FLASK_DEBUG=1


### PR DESCRIPTION
Mounts the source as a volume so code changes are picked up in the container.
By turning on debugging, this lets you work entirely within the container so
you don't need to set up all dependencies locally.

Easiest way to test this is to run:
```
make build
make docker
curl -i http://0.0.0.0:8080/health # should be { "health": true }
# update JSON response in membership_api/membership/web/base_app.py
curl -i http://0.0.0.0:8080/health # should be new response
```

My assumption is that these changes would only affect local development and the production build would not have debugging on. If this looks good, I can update the readme to reflect the changes.

I can follow this up with moving some commands (eg., `make lint`) to be called from inside the container as well.